### PR TITLE
Remove double title on homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/
 .idea
+*.swp

--- a/themes/portzero/layouts/partials/head.html
+++ b/themes/portzero/layouts/partials/head.html
@@ -2,7 +2,7 @@
 	<base href="{{ .Site.BaseURL }}">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{- .Title }} - {{ .Site.Title -}}</title>
+	<title>{{- .Title }}{{ if not .IsHome}} - {{ .Site.Title -}}{{ end }}</title>
 	<link rel="shortcut icon" href="/img/logo.png" />
 	<meta name="description" content="{{ .Site.Params.description }}">
 


### PR DESCRIPTION
Currently on the homepage the title says "Port Zero - Port Zero". This PR removes the site title from the homepage so it just says "Port Zero".