### PR TITLE
Feat/responsive nav

### DIFF
--- a/themes/portzero/layouts/_default/baseof.html
+++ b/themes/portzero/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
 	    <div class="text">
                 {{ block "main" . -}}{{- end }}
             </div>
-            {{  partial "foot.html" .  }}
+            {{  partial "footer.html" .  }}
         </div>
 
         <script src="/js/index.js"></script>

--- a/themes/portzero/layouts/_default/baseof.html
+++ b/themes/portzero/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
     <body>
         <div class="content">
             {{  partial "sidebar.html" .  }}
-		    <div class="text">
+	    <div class="text">
                 {{ block "main" . -}}{{- end }}
             </div>
             {{  partial "foot.html" .  }}

--- a/themes/portzero/layouts/partials/allLanguages.html
+++ b/themes/portzero/layouts/partials/allLanguages.html
@@ -1,10 +1,11 @@
-<form style="text-align: right;">
-  <label for="language">{{ i18n "language" . }}</label>
-  <select name="language" id="language">
-    <option value="{{ .Permalink }}" selected>{{ .Language.LanguageName }}</option>
-    {{ range $.Translations }}
-    <option value="{{ .Permalink }}">{{ .Language.LanguageName }}</option>
-    {{ end }}
-  </select>
+<form class="menu_language">
+  <label>{{ i18n "language" . }}
+      <select id="language">
+          <option value="{{ .Permalink }}" selected>{{ .Language.LanguageName }}</option>
+          {{ range $.Translations }}
+          <option value="{{ .Permalink }}">{{ .Language.LanguageName }}</option>
+          {{ end }}
+      </select>
+  </label>
 
 </form>

--- a/themes/portzero/layouts/partials/copyright.html
+++ b/themes/portzero/layouts/partials/copyright.html
@@ -1,0 +1,3 @@
+<p class="copyright">
+    <small>&copy;{{ now.Format "2006" }} by Port Zero</small>
+</p>

--- a/themes/portzero/layouts/partials/foot.html
+++ b/themes/portzero/layouts/partials/foot.html
@@ -1,3 +1,0 @@
-<div class="mobile_footer">
-	{{  partial "footer.html" . }}
-</div>

--- a/themes/portzero/layouts/partials/footer.html
+++ b/themes/portzero/layouts/partials/footer.html
@@ -1,3 +1,6 @@
-<p class="copyright">
-  <small>&copy;{{ now.Format "2006" }} by Port Zero</small>
-</p>
+<div class="mobile_footer">
+    {{ partial "copyright.html" . }}
+    <nav class="menu menu--footer">
+	{{ partial "menu-social" . }}
+    </nav>
+</div>

--- a/themes/portzero/layouts/partials/menu-main.html
+++ b/themes/portzero/layouts/partials/menu-main.html
@@ -1,0 +1,23 @@
+<ul class="menu_main">
+    {{ $currentNode := . }}
+    {{ range .Site.Menus.main -}}
+    <div class="menu_main_item">
+        {{ if .HasChildren }}
+        <li class="withchildren {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }}active{{end}}">
+            <a href="{{ .URL }}">{{ .Name }}</a>
+        </li>
+        <ul class="sub-menu">
+            {{ range .Children }}
+            <li class="{{ if $currentNode.IsMenuCurrent "main" . }}active{{ end }}">
+                <a href="{{ .URL }}">{{ .Name }}</a>
+            </li>
+            {{ end }}
+        </ul>
+        {{ else }}
+        <li class="main-menu {{if ($currentNode.IsMenuCurrent "main" .) }}active{{end}}">
+            <a href="{{.URL}}">{{ .Name }}</a>
+        </li>
+        {{ end }}
+    </div>
+    {{- end  }}
+</ul>

--- a/themes/portzero/layouts/partials/menu-mobile.html
+++ b/themes/portzero/layouts/partials/menu-mobile.html
@@ -1,0 +1,39 @@
+<nav class="menu_mobile">
+    {{ $currentNode := . }}
+    <form id="mobile-menu">
+	<label>
+	    <select>
+		<option value="{{ "/" | relLangURL }}">
+		    Menu
+		</option>
+		{{ range .Site.Menus.main -}}
+		<optgroup>
+		    {{ if .HasChildren }}
+		    <option value="{{ .URL }}" class="withchildren {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }}active{{end}}">
+			{{ .Name }}
+		    </option>
+		    {{ range .Children }}
+		    <option value="{{ .URL }}" class="sub-menu">
+			{{ .Name }}
+		    </option>
+		    {{ end }}
+		    {{ else }}
+		    <option value="{{ .URL }}" class="main-menu {{if ($currentNode.IsMenuCurrent "main" .) }}active{{end}}">
+			{{ .Name }}
+		    </option>
+		    {{ end }}
+		</optgroup>
+		{{- end  }}
+
+		
+		<optgroup>
+		    {{ range $.Translations }}
+		    <option value="{{ .Permalink }}">{{ .Language.LanguageName }}</option>
+		    {{ end }}
+		    <option value="{{ .Permalink }}">{{ .Language.LanguageName }}</option>
+		</optgroup>
+	    </select>
+	</label>
+    </form>
+
+</nav>

--- a/themes/portzero/layouts/partials/menu-mobile.html
+++ b/themes/portzero/layouts/partials/menu-mobile.html
@@ -1,6 +1,6 @@
-<nav class="menu_mobile">
+<nav class="menu">
     {{ $currentNode := . }}
-    <form id="mobile-menu">
+    <form id="mobile-menu" class="menu_mobile">
 	<label>
 	    <select>
 		<option disabled value="{{ "/" | relLangURL }}">
@@ -32,5 +32,4 @@
 	    </select>
 	</label>
     </form>
-
 </nav>

--- a/themes/portzero/layouts/partials/menu-mobile.html
+++ b/themes/portzero/layouts/partials/menu-mobile.html
@@ -3,9 +3,6 @@
     <form id="mobile-menu" class="menu_mobile">
 	<label>
 	    <select>
-		<option disabled value="{{ "/" | relLangURL }}">
-		    Menu
-		</option>
 		{{ range .Site.Menus.main -}}
 		{{ if .HasChildren }}
 		<option value="{{ .URL }}" class="withchildren {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }}active{{end}}">
@@ -13,7 +10,7 @@
 		</option>
 		{{ range .Children }}
 		<option value="{{ .URL }}" class="sub-menu">
-		    {{ .Name }}
+		    &nbsp;&nbsp;{{ .Name }}
 		</option>
 		{{ end }}
 		{{ else }}

--- a/themes/portzero/layouts/partials/menu-mobile.html
+++ b/themes/portzero/layouts/partials/menu-mobile.html
@@ -3,30 +3,27 @@
     <form id="mobile-menu">
 	<label>
 	    <select>
-		<option value="{{ "/" | relLangURL }}">
+		<option disabled value="{{ "/" | relLangURL }}">
 		    Menu
 		</option>
 		{{ range .Site.Menus.main -}}
-		<optgroup>
-		    {{ if .HasChildren }}
-		    <option value="{{ .URL }}" class="withchildren {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }}active{{end}}">
-			{{ .Name }}
-		    </option>
-		    {{ range .Children }}
-		    <option value="{{ .URL }}" class="sub-menu">
-			{{ .Name }}
-		    </option>
-		    {{ end }}
-		    {{ else }}
-		    <option value="{{ .URL }}" class="main-menu {{if ($currentNode.IsMenuCurrent "main" .) }}active{{end}}">
-			{{ .Name }}
-		    </option>
-		    {{ end }}
-		</optgroup>
+		{{ if .HasChildren }}
+		<option value="{{ .URL }}" class="withchildren {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }}active{{end}}">
+		    {{ .Name }}
+		</option>
+		{{ range .Children }}
+		<option value="{{ .URL }}" class="sub-menu">
+		    {{ .Name }}
+		</option>
+		{{ end }}
+		{{ else }}
+		<option value="{{ .URL }}" class="main-menu {{if ($currentNode.IsMenuCurrent "main" .) }}active{{end}}">
+		    {{ .Name }}
+		</option>
+		{{ end }}
 		{{- end  }}
 
-		
-		<optgroup>
+		<optgroup label="{{ i18n "language" }}">
 		    {{ range $.Translations }}
 		    <option value="{{ .Permalink }}">{{ .Language.LanguageName }}</option>
 		    {{ end }}

--- a/themes/portzero/layouts/partials/menu-social.html
+++ b/themes/portzero/layouts/partials/menu-social.html
@@ -1,0 +1,9 @@
+<ul class="menu_social">
+    {{ range .Site.Menus.social -}}
+    <li>
+        <a href="{{.URL}}" target="_BLANK" title="{{ .Name }}">
+            <i class="icon-{{ .Identifier }}"></i>
+        </a>
+    </li>
+    {{- end  }}
+</ul>

--- a/themes/portzero/layouts/partials/menu.html
+++ b/themes/portzero/layouts/partials/menu.html
@@ -1,7 +1,6 @@
 <div class="menu">
     {{ partial "menu-main" . }}
-    {{ partial "menu-mobile" . }}
-
     {{ partial "menu-social" . }}
     {{ partial "allLanguages.html" . }}
+    {{ partial "copyright.html" . }}
 </div>

--- a/themes/portzero/layouts/partials/menu.html
+++ b/themes/portzero/layouts/partials/menu.html
@@ -1,36 +1,7 @@
 <div class="menu">
+    {{ partial "menu-main" . }}
+    {{ partial "menu-mobile" . }}
 
-    <ul class="menu_main">
-
-        {{ $currentNode := . }}
-        {{ range .Site.Menus.main -}}
-            {{ if .HasChildren }}
-                <li class="withchildren {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }}active{{end}}">
-                    <a href="{{ .URL }}">{{ .Name }}</a>
-                </li>
-                <ul class="sub-menu">
-                    {{ range .Children }}
-                        <li class="{{ if $currentNode.IsMenuCurrent "main" . }}active{{ end }}">
-                            <a href="{{ .URL }}">{{ .Name }}</a>
-                        </li>
-                    {{ end }}
-                </ul>
-            {{ else }}
-                <li class="main-menu {{if ($currentNode.IsMenuCurrent "main" .) }}active{{end}}">
-                    <a href="{{.URL}}">{{ .Name }}</a>
-                </li>
-            {{ end }}
-        {{- end  }}
-    </ul>
-
-    <ul class="menu_social">
-        {{ range .Site.Menus.social -}}
-        <li>
-            <a href="{{.URL}}" target="_BLANK" title="{{ .Name }}">
-                <i class="icon-{{ .Identifier }}"></i>
-            </a>
-        </li>
-        {{- end  }}
-    </ul>
-
+    {{ partial "menu-social" . }}
+    {{ partial "allLanguages.html" . }}
 </div>

--- a/themes/portzero/layouts/partials/sidebar.html
+++ b/themes/portzero/layouts/partials/sidebar.html
@@ -1,15 +1,9 @@
 <div class="sidebar">
-  {{ if eq .Language.LanguageName "Deutsch"}}
-  <a class="Logo" href="/de/">
-    {{ else }}
-    <a class="Logo" href="/">
-      {{ end }}
-      <img src="img/logo.svg" alt="Port Zero"/>
+    <a class="Logo" href="{{ "/" | relLangURL }}">
+	<img src="img/logo.svg" alt="Port Zero"/>
     </a>
 
-  {{ partial "menu.html" . }}
+    {{ partial "menu.html" . }}
 
-  {{ partial "allLanguages.html" . }}
-
-  {{ partial "footer.html" . }}
+    {{ partial "footer.html" . }}
 </div>

--- a/themes/portzero/layouts/partials/sidebar.html
+++ b/themes/portzero/layouts/partials/sidebar.html
@@ -4,6 +4,5 @@
     </a>
 
     {{ partial "menu.html" . }}
-
-    {{ partial "footer.html" . }}
+    {{ partial "menu-mobile" . }}
 </div>

--- a/themes/portzero/static/css/style.css
+++ b/themes/portzero/static/css/style.css
@@ -87,10 +87,6 @@ hr {
   margin-left: 0;
 }
 
-select option[active] {
-    font-weight: 400;
-}
-
 /* Layout */
 html,
 body {

--- a/themes/portzero/static/css/style.css
+++ b/themes/portzero/static/css/style.css
@@ -150,6 +150,13 @@ body {
 .sidebar .sub-menu {
     font-size: 1.0rem;
 }
+.menu_mobile option {
+    font-size: 1rem;
+}
+.menu_mobile optgroup[label] {
+    font-size: 1rem;
+}
+
 
 /* Menu */
 .menu {

--- a/themes/portzero/static/css/style.css
+++ b/themes/portzero/static/css/style.css
@@ -126,7 +126,7 @@ body {
 }
 @media (min-width: 40rem) {
     .sidebar {
-	max-width: 20rem;
+	max-width: 17rem;
 	flex-direction: column;
 	justify-content: flex-start;
 	align-items: flex-end;
@@ -282,9 +282,16 @@ body {
 
 .mobile_footer {
   padding-top: 2rem;
-  text-align: center;
   display: flex;
+  flex-direction: column;
 }
+.mobile_footer .menu_social {
+    display: flex;
+    list-style: none;
+    font-size: 1.2rem;
+    padding-left: 0;
+}
+
 @media (min-width: 40rem) {
     .mobile_footer {
 	display: none;

--- a/themes/portzero/static/css/style.css
+++ b/themes/portzero/static/css/style.css
@@ -16,19 +16,21 @@
     url('../font/fira-sans-v8-latin-400.woff') format('woff');
 }
 
+/*
+   border box, for easier box model reasonning;
+   and flex overflows miscaculations */
+html {
+    box-sizing: border-box;
+}
+*, *:before, *:after {
+    box-sizing: inherit;
+}
+
 html {
   font-family: 'Fira Sans';
   font-weight: 300;
   line-height: 1.4;
-}
-
-html,
-body {
-  min-height: 100%;
-}
-
-body {
-  margin: 0;
+  font-size: 16px;
 }
 
 h1,
@@ -85,90 +87,159 @@ hr {
   margin-left: 0;
 }
 
+select option[active] {
+    font-weight: 400;
+}
+
 /* Layout */
+html,
+body {
+    min-height: 100%;
+    display: flex;
+    width: 100%;
+}
+body {
+    margin: 0;
+    /* The base for laying out with flex child elements, 
+     so they are centered */
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    align-items: center;
+}
 
 .content {
   max-width: 60rem;
-  margin: 2rem auto 1rem;
+  display: flex;
+  width: 100%;
+  padding: 2rem;
+  flex-grow: 1;
 }
 
 .sidebar,
 .text {
-  padding-left: 1.25rem;
-  padding-right: 1.25rem;
+  width: 100%;
 }
 
+/* sidebar */
 .sidebar {
-  float: left;
-  width: 33%;
-  max-width: 200px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2rem;
 }
-
-.text {
-  margin-left: 260px;
+@media (min-width: 40rem) {
+    .sidebar {
+	max-width: 20rem;
+	flex-direction: column;
+	justify-content: flex-start;
+	align-items: flex-end;
+	padding-right: 3rem;
+    }
+}
+.sidebar .copyright {
+    display: none;
+    text-align: right;
+    color: black;
+    margin-bottom: 1rem;
+}
+@media (min-width: 40rem) {
+    .content .copyright {
+	display: block;
+    }
+}
+.sidebar .main-menu {
+    margin-bottom: 1rem;
+}
+.sidebar .sub-menu {
+    font-size: 1.0rem;
 }
 
 /* Menu */
-
 .menu {
   font-weight: 400;
   text-align: right;
+  display: flex;
+  flex-direction: column;
+}
+.menu ul {
+    padding: 0;
+    list-style: none;
+    font-size: 1.5rem;
+}
+.menu li {
+    display: flex;
+    justify-content: flex-end;
+}
+.menu a {
+    padding: 0.1rem 0.5rem;
 }
 
-.menu ul {
-  padding: 0;
-  list-style: none;
-  font-size: 1.25rem;
+.menu_main {
+    display: none;
+    margin-left: 1rem;
+}
+@media (min-width: 40rem) {
+    .menu_main {
+	display: block;
+    }    
+}
+.menu_language {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    display : none;
+}
+@media (min-width: 40rem) {
+    .menu_language {
+	display: block;
+    }    
+}
+
+.menu_mobile select {
+    padding: 0.4rem;
+    font-size: 1.2rem;
+    background-color: transparent;
+    border-width: 0.1rem;
+    text-align: left;
+}
+.menu_mobile select option {
+    margin-left: 0;
+}
+@media (min-width: 40rem) {
+    .menu_mobile {
+	display: none;
+    }    
 }
 
 .menu .withchildren:first-of-type {
   /* font-weight: normal; */
 }
 
-.sidebar .main-menu {
-  margin-bottom: 1rem;
-}
-
-.sidebar .sub-menu {
-  font-size: 1.0rem;
-}
-
 .menu .active > a {
   color: black;
 }
 
-.sidebar .menu .menu_social li {
-  display: inline;
+.menu_social {
+    display: none;
+}
+@media (min-width: 40rem) {
+    .menu_social {
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-end;
+    }    
 }
 
-.sidebar .menu .menu_social li a {
+.menu_social li a {
   color: #212529;
 }
 
-.sidebar .menu .menu_social li a:hover {
-  text-decoration: none;
-}
-
-.sidebar .language {
-  text-align: right;
-  margin-bottom: 0;
-  color: black;
-}
-
-.sidebar .copyright {
-  text-align: right;
-  color: black;
-  margin-bottom: 1rem;
-}
-
-
-.sidebar .language a {
-  color: black;
+.menu_social li a:hover {
   text-decoration: none;
 }
 
 /* Logo */
-
 .Logo {
   display: block;
   text-align: right;
@@ -182,6 +253,7 @@ hr {
   width: 64px;
 }
 
+/* footer */
 .footer {
   width: 100%;
   display: flex;
@@ -213,12 +285,17 @@ hr {
 }
 
 .mobile_footer {
-  display: none;
-  border-top: 1px solid #0d96d5;
-  padding-top: 1rem;
+  padding-top: 2rem;
   text-align: center;
+  display: flex;
+}
+@media (min-width: 40rem) {
+    .mobile_footer {
+	display: none;
+    }    
 }
 
+/* imprint */
 .imprint-legalese {
   max-width: 700px;
   max-height: 400px;
@@ -271,20 +348,11 @@ hr {
 }
 
 /* Smaller screens */
-@media (max-width: 649px) {
-  .sidebar {
-    float: none;
-    width: auto;
-    max-width: none;
-    border-bottom: 1px solid #0d96d5;
-    margin-bottom: 1rem;
-  }
-
+@media (max-width: 40rem) {
   .text {
     margin-left: 0;
   }
-
-  .mobile_footer {
-    display: block;
+  .content {
+      flex-direction: column;
   }
 }

--- a/themes/portzero/static/js/index.js
+++ b/themes/portzero/static/js/index.js
@@ -1,7 +1,10 @@
-document.addEventListener('DOMContentLoaded', function (event) {
-  document.getElementById('language').addEventListener('change', function onChangeLanguage (event) {
+function onSelectChange (event) {
     if (window.location.href !== event.target.value) {
-      window.location = event.target.value
+	window.location.href = event.target.value
     }
-  })
+}
+
+document.addEventListener('DOMContentLoaded', function (event) {
+    document.getElementById('language').addEventListener('change', onSelectChange)
+    document.getElementById('mobile-menu').addEventListener('change', onSelectChange)
 })


### PR DESCRIPTION
An attempt into making the site's navigation more responsive.

Tried a solution with the pattern existing for language switch, with an html `select` element.

Overview:
- add `menu_mobile` html select, and hide `menu_main` and `menu_social` 
- templates for the different menus
- simplify p0 logo link for multi language
- css media queries now use `min-width` instead of `max-width`, for mobile first logic
- these have also been moved closer to the css class definition
- reorganize slightly css order to reflect html component usage