### PR TITLE
use rsync instead of scp to delete/clean destination folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,5 +9,8 @@ jobs:
           fingerprints:
             - "64:26:04:aa:33:2d:f6:45:f4:79:df:c8:60:2b:d0:6a"
       - run:
+          name: Install rsync
+          command: 'sudo apt install rsync'
+      - run:
           name: Build and Deploy
           command: ./scripts/build_and_deploy.sh

--- a/scripts/build_and_deploy.sh
+++ b/scripts/build_and_deploy.sh
@@ -6,12 +6,12 @@ if [[ $CIRCLE_BRANCH == master ]]; then
   echo 'Building for production...'
   hugo
   echo 'Deploying to production...'
-  scp -i ~/.ssh/id_rsa -o "StrictHostKeyChecking no" -r public/* root@web01.port-ze.ro:/srv/www/port-zero.com/html
+  rsync --recursive --delete public/ root@web01.port-ze.ro:/srv/www/port-zero.com/html
 elif [[ $CIRCLE_BRANCH == staging ]]; then
   echo 'Building for staging...'
   hugo --baseURL="https://staging.port-zero.com/"
   echo 'Deploying to staging...'
-  scp -i ~/.ssh/id_rsa -o "StrictHostKeyChecking no" -r public/* root@web01.port-ze.ro:/srv/www/staging.port-zero.com/html
+  rsync --recursive --delete public/ root@web01.port-ze.ro:/srv/www/staging.port-zero.com/html
 else
   echo 'Building...'
   hugo


### PR DESCRIPTION
To deploy the site, we've used `scp`, and it seems that it has the side effect of letting at the destination path, old files that should not exist.

To clean the destination folder when deploying a new site (where pages might have been added, *and removed*), we're now using `rsync` with the `--delete` flag.

Does that look alright? In my local tests it seems to work.

The one think I don't like about this new solution, is that the `/` trailing slash after the input path is required, otherwise it is the folder itself that is copied to the destination path, and not its content. 

Do you see a way to improve the readability of this command?

PS: also, I am not sure that it will work without specifying the identity file to be used, since it was done in the previous command