### PR TITLE
add a circleci build step to verify deploy host authenticity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,5 +12,8 @@ jobs:
           name: Install rsync
           command: 'sudo apt install rsync'
       - run:
+          name: Providing the Hostkey for Verification
+          command: echo $HOSTKEY_WEB01_P0 >> ~/.ssh/known_hosts
+      - run:
           name: Build and Deploy
           command: ./scripts/build_and_deploy.sh


### PR DESCRIPTION
Because the `web01.port-zero.com` is not in known host, rsync (via ssh), does not want to deploy there until human acceptance (yes/no answer) of the hosts' ssh key fingerprint.

This PR tries to fix this, by adding the key (found with `ssh-keyscan`), as a circleci environment variable, `$HOSTKEY_WEB01_P0`.

![1582017570](https://user-images.githubusercontent.com/1502484/74721618-f6789d00-5237-11ea-889c-9f857332a287.png)

Some docs:
- https://discuss.circleci.com/t/the-authenticity-of-host-heroku-com-50-19-85-132-cant-be-established/17910
- https://forestry.io/blog/circleci-deploy-via-rsync/
