### PR TITLE
style: avoid images overflowing vertically

### DIFF
--- a/themes/portzero/static/css/style.css
+++ b/themes/portzero/static/css/style.css
@@ -77,6 +77,10 @@ hr {
   border-bottom: 1px solid #0d96d5;
 }
 
+img {
+  width: 100%;
+}
+
 .lead {
   font-size: 1.25rem;
   font-weight: 300;


### PR DESCRIPTION
This PR avoids an issue of images overflowing veritcally (as it currently does e.g. on [development](https://port-zero.com/competences/dev/)).

Cheers